### PR TITLE
Changed sudo to become and improved reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Edit the `wpa_supplicant.conf` and `hosts` files.
 Deploy using [ansible](http://www.ansible.com) (install instructions for ansible are in [requirements](#requirements) below).
 
 ```
-ansible-playbook playbook.yml -i hosts --ask-pass --sudo -c paramiko
+ansible-playbook playbook.yml -i hosts --ask-pass --become -c paramiko
 ```
 
 ## Requirements

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,4 +6,4 @@
   roles:
     - pi
   remote_user: pi
-  sudo: yes
+  become: yes

--- a/roles/pi/tasks/main.yml
+++ b/roles/pi/tasks/main.yml
@@ -9,5 +9,11 @@
   action: apt upgrade=safe
 
 - name: 'Reboot'
-  command: /sbin/reboot -t now
+  command: sleep 2 && reboot
+  async: 1
+  poll: 0
+  ignore_errors: true
 
+- name: "Wait for Raspberry PI to come back"
+  local_action: wait_for host={{ ansible_ssh_host }} port=22 state=started delay=10
+  become: false


### PR DESCRIPTION
Two changes in this PR:
- `sudo` is deprecated, see http://docs.ansible.com/ansible/become.html.
- Improved rebooting. reboot fails due to two reasons: 1) the `-t now` param is not supported in latest Raspbian image; 2) the reboot itself will fail the ansible play due to some ssh race condition. I updated the command and have added a wait for pi to come back.
